### PR TITLE
Allow format hook to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ To update, `cd` into your clone and `git pull`.
 Whenever you finish your command line, `zsh-hist` will automatically format it for you, before it
 is saved to history. You can also retroactively format your history with
 [`hist n`](#hist-command-syntax).
+You can also disable automatic history format with:
+```zsh
+zstyle ':hist:*' disable-format-hook yes
+```
 
 **Notes:**
 * For the formatting to be preserved completely when the command is saved history, you need to

--- a/zsh-hist.plugin.zsh
+++ b/zsh-hist.plugin.zsh
@@ -17,17 +17,19 @@ zsh-hist() {
 
   zle -N undo .hist.undo.widget
 
-  autoload -Uz add-zsh-hook
-  :hist:precmd() {
-    local 0=${(%):-%N}
-    add-zsh-hook -d precmd $0
-    unfunction $0
+  if ! zstyle -t :hist: disable-format-hook; then
+    autoload -Uz add-zsh-hook
+    :hist:precmd() {
+      local 0=${(%):-%N}
+      add-zsh-hook -d precmd $0
+      unfunction $0
 
-    autoload -Uz add-zle-hook-widget
-    add-zle-hook-widget line-init .hist.format.hook
-    add-zle-hook-widget line-finish .hist.format.hook
-  }
-  add-zsh-hook precmd :hist:precmd
+      autoload -Uz add-zle-hook-widget
+      add-zle-hook-widget line-init .hist.format.hook
+      add-zle-hook-widget line-finish .hist.format.hook
+    }
+    add-zsh-hook precmd :hist:precmd
+  fi
 }
 
 {


### PR DESCRIPTION
Personally I don't like my oneliners to be multiline formatted. If there's a better way please let me know.