### PR TITLE
Prevent loading of format hooks until session is loaded

### DIFF
--- a/zsh-hist.plugin.zsh
+++ b/zsh-hist.plugin.zsh
@@ -1,4 +1,5 @@
 #!/bin/zsh
+zstyle ':hist:*' load-hooks true
 unsetopt flowcontrol
 
 zsh-hist() {
@@ -23,8 +24,11 @@ zsh-hist() {
     unfunction $0
 
     autoload -Uz add-zle-hook-widget
-    add-zle-hook-widget line-init .hist.format.hook
-    add-zle-hook-widget line-finish .hist.format.hook
+    if zstyle -T ':hist:*' load-hooks; then
+        add-zle-hook-widget line-init .hist.format.hook
+        add-zle-hook-widget line-finish .hist.format.hook
+    fi
+
   }
   add-zsh-hook precmd :hist:precmd
 }


### PR DESCRIPTION
Prevent loading of format hooks until session is loaded 
This is a work around for incompatability with: https://github.com/zdharma-continuum/fast-syntax-highlighting/issues/65